### PR TITLE
Add `.tool-versions` file for use with `asdf` / `mise`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.16.3-otp-26
+erlang 26.2.5


### PR DESCRIPTION
I often use `mise` for language version management, so I figured I'd add a `.tool-versions` file. 🙏 

Documentation refs:
- https://asdf-vm.com/manage/versions.html#via-tool-versions-file
- https://mise.jdx.dev/dev-tools/#how-it-works