### PR TITLE
Generalize key and path to use term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.8.4] - Unreleased
 
+### Added
+
+* `Funx.Optics.Prism` – Generalized `key/1` and `path/1` to support any `term()` as a key. This allows for easier navigation of JSON-like data with string keys while maintaining support for atom keys and struct-typed field access.
+
 ### Updated
 
 Small fix for Pred/Eq/Ord DSLs

--- a/lib/optics/prism.ex
+++ b/lib/optics/prism.ex
@@ -76,6 +76,13 @@ defmodule Funx.Optics.Prism do
       iex> person_name = Funx.Optics.Prism.path([:person, :name])
       iex> Funx.Optics.Prism.preview(%{person: %{name: "Alice"}}, person_name)
       %Funx.Monad.Maybe.Just{value: "Alice"}
+
+  Working with JSON-like string-keyed data:
+
+      iex> data = %{"user" => %{"profile" => %{"name" => "Alice"}}}
+      iex> name = Funx.Optics.Prism.path(["user", "profile", "name"])
+      iex> Funx.Optics.Prism.preview(data, name)
+      %Funx.Monad.Maybe.Just{value: "Alice"}
   """
 
   import Funx.Monoid.Utils, only: [m_append: 3, m_concat: 2]
@@ -109,9 +116,12 @@ defmodule Funx.Optics.Prism do
       %Funx.Monad.Maybe.Just{value: "Alice"}
       iex> Funx.Optics.Prism.preview(%{age: 30}, p)
       %Funx.Monad.Maybe.Nothing{}
+      iex> p = Funx.Optics.Prism.key("name")
+      iex> Funx.Optics.Prism.preview(%{"name" => "Alice"}, p)
+      %Funx.Monad.Maybe.Just{value: "Alice"}
   """
-  @spec key(atom) :: t(map(), any)
-  def key(k) when is_atom(k) do
+  @spec key(term()) :: t(map(), any)
+  def key(k) do
     make(
       fn
         %{} = m -> m |> Map.get(k) |> Maybe.from_nil()
@@ -185,16 +195,16 @@ defmodule Funx.Optics.Prism do
   Builds a prism that focuses on a nested path through maps and structs.
 
   Each element in the path can be:
-  - `:atom` - A plain key access (works with maps and structs)
+  - `term()` - A plain key access (works with maps and structs)
   - `Module` - A naked struct verification (checks type, no key access)
-  - `{Module, :atom}` - A struct-typed key access (verifies struct type and accesses key)
+  - `{Module, atom}` - A struct-typed key access (verifies struct type and accesses key)
 
   The syntax expands as follows:
-  - `:key` → `key(:key)` - plain key access
+  - `key` → `key(key)` - plain key access
   - `Module` → `struct(Module)` - struct type verification
-  - `{Module, :key}` → `compose(struct(Module), key(:key))` - typed field access
+  - `{Module, key}` → `compose(struct(Module), key(key))` - typed field access
 
-  Modules are distinguished from plain keys using `function_exported?(atom, :__struct__, 0)`.
+  Struct modules are distinguished from plain atom keys using `function_exported?(atom, :__struct__, 0)`.
 
   ## Examples
 
@@ -202,6 +212,11 @@ defmodule Funx.Optics.Prism do
       p1 = Prism.path([:person, :bio, :age])
       Prism.review(30, p1)
       #=> %{person: %{bio: %{age: 30}}}
+
+      # String-keyed path
+      p1b = Prism.path(["person", "bio", "age"])
+      Prism.review(30, p1b)
+      #=> %{"person" => %{"bio" => %{"age" => 30}}}
 
       # Given struct modules:
       defmodule Bio do
@@ -240,20 +255,21 @@ defmodule Funx.Optics.Prism do
   ## Implementation
 
   The `path/1` function composes prisms using `compose/1`:
-  - `:key` → `[key(:key)]`
+  - `key` → `[key(key)]`
   - `Module` → `[struct(Module)]`
-  - `{Mod, :key}` → `[struct(Mod), key(:key)]`
+  - `{Mod, atom_key}` → `[struct(Mod), key(atom_key)]`
 
   This means `path` is just syntactic sugar for prism composition.
 
   ## Important
 
-  - When using `{Module, :field}`, ensure `:field` exists in `Module`
+  - When using `{Module, field}`, `field` should be an atom key that exists in `Module`
   - Using non-existent fields may violate prism laws (Kernel.struct/2 silently drops invalid keys)
-  - The tuple form `{Module, :key}` requires `Module` to be a struct module (raises otherwise)
+  - The tuple form `{Module, key}` is only treated specially when `Module` is a struct module and `key` is an atom
+  - All other path segments, including non-atom values and non-struct tuples, are treated as plain map keys
   - Plain lowercase atoms like `:user` are always treated as keys, not struct modules
   """
-  @spec path([atom | {module, atom}]) :: t(map(), any)
+  @spec path([term() | {module, atom()}]) :: t(map(), any)
   def path(path) when is_list(path) do
     prisms =
       Enum.flat_map(path, fn
@@ -261,9 +277,11 @@ defmodule Funx.Optics.Prism do
           if function_exported?(mod, :__struct__, 0) do
             [struct(mod), key(key)]
           else
-            raise ArgumentError,
-                  "#{inspect(mod)} in {#{inspect(mod)}, #{inspect(key)}} is not a struct module"
+            [key({mod, key})]
           end
+
+        {mod, key} when is_atom(mod) ->
+          [key({mod, key})]
 
         atom when is_atom(atom) ->
           if function_exported?(atom, :__struct__, 0) do
@@ -272,9 +290,8 @@ defmodule Funx.Optics.Prism do
             [key(atom)]
           end
 
-        invalid ->
-          raise ArgumentError,
-                "path/1 expects atoms or {Module, :key} tuples, got: #{inspect(invalid)}"
+        key ->
+          [key(key)]
       end)
 
     compose(prisms)

--- a/test/optics/prism_test.exs
+++ b/test/optics/prism_test.exs
@@ -141,6 +141,44 @@ defmodule Funx.Optics.PrismTest do
 
       assert Prism.review(50, p) == %{age: 50}
     end
+
+    test "supports string keys" do
+      p = Prism.key("age")
+
+      assert %Just{value: 40} = Prism.preview(%{"age" => 40}, p)
+      assert %Nothing{} = Prism.preview(%{"name" => "Alice"}, p)
+      assert Prism.review(50, p) == %{"age" => 50}
+    end
+
+    test "supports integer keys" do
+      p = Prism.key(1)
+
+      assert %Just{value: 40} = Prism.preview(%{1 => 40}, p)
+      assert %Nothing{} = Prism.preview(%{2 => 40}, p)
+      assert Prism.review(50, p) == %{1 => 50}
+    end
+
+    test "supports composite term keys" do
+      key = {:profile, "age"}
+      p = Prism.key(key)
+
+      assert %Just{value: 40} = Prism.preview(%{key => 40}, p)
+      assert %Nothing{} = Prism.preview(%{{:profile, "name"} => "Alice"}, p)
+      assert Prism.review(50, p) == %{key => 50}
+    end
+
+    test "supports composed access over string-keyed JSON-like maps" do
+      hero = %{
+        "powers" => %{
+          "strength" => 9000
+        }
+      }
+
+      powers_prism = Prism.key("powers")
+      strength_prism = Prism.compose(powers_prism, Prism.key("strength"))
+
+      assert %Just{value: 9000} = Prism.preview(hero, strength_prism)
+    end
   end
 
   # ============================================================================
@@ -178,6 +216,19 @@ defmodule Funx.Optics.PrismTest do
     test "review rebuilds structure from focused value" do
       p = Prism.path([:a, :b, :c])
       assert Prism.review(7, p) == %{a: %{b: %{c: 7}}}
+    end
+
+    test "supports string-keyed JSON-like paths" do
+      hero = %{
+        "powers" => %{
+          "strength" => 9000
+        }
+      }
+
+      p = Prism.path(["powers", "strength"])
+
+      assert %Just{value: 9000} = Prism.preview(hero, p)
+      assert Prism.review(42, p) == %{"powers" => %{"strength" => 42}}
     end
 
     test "path prism composes with struct prism" do
@@ -450,36 +501,31 @@ defmodule Funx.Optics.PrismTest do
       assert result == %User{name: "Alice", profile: nil}
     end
 
-    test "raises when tuple has non-struct module" do
-      assert_raise ArgumentError, ~r/:not_a_module.*is not a struct module/, fn ->
-        Prism.path([{:not_a_module, :key}])
-      end
+    test "treats tuples with non-struct module atoms as plain keys" do
+      p = Prism.path([{:not_a_module, :key}])
+
+      assert %Just{value: "value"} = Prism.preview(%{{:not_a_module, :key} => "value"}, p)
+      assert Prism.review("value", p) == %{{:not_a_module, :key} => "value"}
     end
 
-    test "raises when path contains invalid element" do
-      assert_raise ArgumentError,
-                   ~r/path\/1 expects atoms or \{Module, :key\} tuples, got: "string"/,
-                   fn ->
-                     Prism.path(["string"])
-                   end
+    test "accepts non-atom path elements as plain keys" do
+      assert %Just{value: "Alice"} = Prism.preview(%{"name" => "Alice"}, Prism.path(["name"]))
+      assert %Just{value: "one"} = Prism.preview(%{1 => "one"}, Prism.path([1]))
+      assert %Just{value: true} = Prism.preview(%{%{} => true}, Prism.path([%{}]))
+    end
 
-      assert_raise ArgumentError,
-                   ~r/path\/1 expects atoms or \{Module, :key\} tuples, got: 123/,
-                   fn ->
-                     Prism.path([123])
-                   end
+    test "treats atom-first tuples as plain keys unless key is an atom on a struct module" do
+      p = Prism.path([{:user, 1}])
 
-      assert_raise ArgumentError,
-                   ~r/path\/1 expects atoms or \{Module, :key\} tuples, got: %\{\}/,
-                   fn ->
-                     Prism.path([%{}])
-                   end
+      assert %Just{value: true} = Prism.preview(%{{:user, 1} => true}, p)
+      assert Prism.review("value", p) == %{{:user, 1} => "value"}
     end
 
     test "raises when tuple has non-atom key" do
-      assert_raise ArgumentError, ~r/path\/1 expects atoms or \{Module, :key\} tuples/, fn ->
-        Prism.path([{User, "name"}])
-      end
+      p = Prism.path([{User, "name"}])
+
+      assert %Just{value: "Alice"} = Prism.preview(%{{User, "name"} => "Alice"}, p)
+      assert Prism.review("Bob", p) == %{{User, "name"} => "Bob"}
     end
   end
 
@@ -719,16 +765,6 @@ defmodule Funx.Optics.PrismTest do
   # ============================================================================
 
   describe "malformed prism construction" do
-    test "key/1 raises for non-atom" do
-      assert_raise FunctionClauseError, fn ->
-        Prism.key("not_an_atom")
-      end
-
-      assert_raise FunctionClauseError, fn ->
-        Prism.key(123)
-      end
-    end
-
     test "struct/1 raises for non-struct module" do
       assert_raise ArgumentError,
                    ~r/String is not a struct module/,

--- a/usage-rules/optics_prism.md
+++ b/usage-rules/optics_prism.md
@@ -19,12 +19,13 @@
 
 **Key Path Syntax:**
 
-- `:atom` - Plain key access (works with maps and structs)
+- `term()` - Plain key access (works with maps and structs)
 - `Module` - Naked struct verification (checks type, no key access)
-- `{Module, :atom}` - Struct-typed field access (verifies struct type, then accesses key)
+- `{Module, atom}` - Struct-typed field access (verifies struct type, then accesses key)
 - Modules are distinguished from keys using `function_exported?(atom, :__struct__, 0)`
 - Examples:
-  - `path([:user, :profile])` - plain keys only
+  - `path([:user, :profile])` - plain atom keys
+  - `path(["user", "profile"])` - string keys (JSON-like)
   - `path([User, :profile])` - verify root is User, then get :profile
   - `path([{User, :profile}, Profile])` - typed field access, then verify Profile
   - `path([Person])` - just verify type (no field access)
@@ -162,7 +163,12 @@ p1 = Prism.path([:user, :profile, :email])
 Prism.review("alice@example.com", p1)
 #=> %{user: %{profile: %{email: "alice@example.com"}}}
 
-# Struct-typed path using {Module, :key} syntax
+# String-keyed path
+p1b = Prism.path(["user", "profile", "email"])
+Prism.review("alice@example.com", p1b)
+#=> %{"user" => %{"profile" => %{"email" => "alice@example.com"}}}
+
+# Struct-typed path using {Module, atom} syntax
 defmodule Profile, do: defstruct [:email, :age]
 defmodule User, do: defstruct [:name, :profile]
 
@@ -193,17 +199,17 @@ Prism.review("alice@example.com", p6)
 
 **Syntax:**
 
-- `:atom` - Plain key access
+- `term()` - Plain key access
 - `Module` - Naked struct verification (just type check, no field access)
-- `{Module, :atom}` - Typed field access (struct check + key access)
+- `{Module, atom}` - Typed field access (struct check + key access)
 
 **How it works:**
 
-- `:key` → `key(:key)`
+- `key` → `key(key)`
 - `Module` → `struct(Module)` (when Module has `__struct__/0`)
-- `{Module, :key}` → `compose(struct(Module), key(:key))`
+- `{Module, atom_key}` → `compose(struct(Module), key(atom_key))`
 
-**IMPORTANT**: Only use `{Module, :field}` when `:field` exists in `Module`. Using non-existent fields may violate prism laws.
+**IMPORTANT**: Only use `{Module, field}` when `field` exists in `Module`. Using non-existent fields may violate prism laws.
 
 ### `struct/1` - Focus on Struct Type
 


### PR DESCRIPTION
Generalized `key/1` and `path/1` to support any `term()` as a key. This allows for easier navigation of JSON-like data with string keys while maintaining support for atom keys and struct-typed field access.